### PR TITLE
Python3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+pydynamixel/__pycache__

--- a/pydynamixel/chain.py
+++ b/pydynamixel/chain.py
@@ -101,8 +101,8 @@ the program waits until all servos have finished moving before moving to the nex
 
 """
 
-import dynamixel
-import packets
+from . import dynamixel
+from . import packets
 import time
 
 NUM_ERROR_ATTEMPTS = 10

--- a/pydynamixel/packets.py
+++ b/pydynamixel/packets.py
@@ -15,7 +15,7 @@ where ``checksum`` is the complement of the lowest byte of the sum of the data b
 
 """
 
-import registers
+from . import registers
         
 ### Packet-Formatting Functions
 


### PR DESCRIPTION
Hi Richard - thanks for PyDynamixel!

I needed to make it work under Python3, so made the minimal changes for that to happen, which is basically just taking into account the fact that the serial library returns bytes rather than a str, and you can therefore just treat them individually as ints without having to do a struct.unpack to get their integer values.

I'm afraid my version probably no longer works under Python 2, so you may not want to merge it! Feel free to discard this PR in that case - I won't be offended!

All the best, 
Quentin
